### PR TITLE
fix: resolve CSS loading issue on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -37,8 +37,10 @@ jobs:
       run: |
         cd ${{ env.BOOK_DIR }}
         jupyter-book build .
-        
-          
+
+    - name: Add .nojekyll file
+      run: touch ./_build/html/.nojekyll
+
     - name: Deploy to GitHub Pages
       if: github.ref == 'refs/heads/concise' && github.event_name == 'push'  # Only deploy on push to concise branch
       uses: peaceiris/actions-gh-pages@v4

--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ html:
   analytics:
     google_analytics_id: "G-BT4TZCELT2"
   home_page_in_navbar: true
-  baseurl: ""
+  baseurl: "/opticsTextbook"
   comments:
     hypothesis: true
     utterances: false


### PR DESCRIPTION
- Set baseurl to "/opticsTextbook" for proper asset paths
- Add .nojekyll file to prevent Jekyll processing
- This fixes the CSS/JS loading issue at veillette.github.io/opticsTextbook/

Changes:
1. _config.yml: baseurl "" -> "/opticsTextbook"
2. deploy-book.yml: Added step to create .nojekyll file in build output

The empty baseurl caused all CSS/JS paths to resolve incorrectly when deployed to a GitHub Pages project site (not user/org site).