### PR TITLE
revert: restore empty baseurl for GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,7 +56,7 @@ html:
   analytics:
     google_analytics_id: "G-BT4TZCELT2"
   home_page_in_navbar: true
-  baseurl: "/opticsTextbook"
+  baseurl: ""
   comments:
     hypothesis: true
     utterances: false


### PR DESCRIPTION
The baseurl="/opticsTextbook" was causing a 404 error. Jupyter Book on GitHub Pages should use an empty baseurl - the gh-pages deployment handles the URL prefix automatically.

The 404 issue is likely due to GitHub Pages configuration, not the baseurl setting. Need to verify:
1. GitHub Pages is enabled in repo settings
2. Source is set to gh-pages branch
3. The gh-pages branch exists and has content