### PR TITLE
Fix broken Khan Academy educational links

### DIFF
--- a/content/Chap04Polarization/Polarization.md
+++ b/content/Chap04Polarization/Polarization.md
@@ -224,7 +224,7 @@ Illustration of different types of polarization. The horizontal and vertical arr
 
 
 ```{admonition} External source
-- [KhanAcademy - Polarization of light, linear and circular](https://www.khanacademy.org/science/physics/light-waves/introduction-to-light-waves/v/polarization-of-light-linear-and-circular): Explanation of different polarization states and their applications.
+- [KhanAcademy - Polarization of light, linear and circular](https://www.khanacademy.org/science/ap-physics-2/ap-light-waves/ap-introduction-to-light-waves/v/polarization-of-light-linear-and-circular): Explanation of different polarization states and their applications.
 ```
 
 ## Creating and Manipulating Polarization States

--- a/content/Chap06Interference/InterferenceCoherence.md
+++ b/content/Chap06Interference/InterferenceCoherence.md
@@ -1376,7 +1376,7 @@ the two constituent orthogonal linearly polarized states of natural light cannot
 
 
 ```{admonition} External sources in recommended order
-1. [KhanAcademy - Interference of light waves](https://www.khanacademy.org/science/physics/light-waves/interference-of-light-waves/v/wave-interference): Playlist on wave interference at secondary school level.
+1. [KhanAcademy - Interference of light waves](https://www.khanacademy.org/science/ap-physics-1/ap-mechanical-waves-and-sound/wave-interference-ap/v/wave-interference-pulses): Playlist on wave interference at secondary school level.
 2. [Yale Courses - 18. Wave Theory of Light](https://www.youtube.com/watch?v=5tKPLfZ9JVQ)
 3. {cite:t}`born_wolf_coherence`: Comprehensive treatment of coherence theory
 4. {cite:t}`michelson_interferometer`: Original paper on interferometry
@@ -1393,7 +1393,7 @@ Demonstration of an interference pattern obtained with sunlight.
 
 [^4]: [MIT OCW - Coherence Length and Source Spectrum](https://ocw.mit.edu/resources/res-6-006-video-demonstrations-in-lasers-and-optics-spring-2008/demonstrations-in-physical-optics/coherence-length-and-source-spectrum/): Demonstration of how the coherence length depends on the spectrum of the laser light.
 
-[^5]: [KhanAcademy - Young's Double slit part 1](https://www.khanacademy.org/science/physics/light-waves/interference-of-light-waves/v/youngs-double-split-part-1)
+[^5]: [KhanAcademy - Young's Double slit part 1](https://www.khanacademy.org/science/in-in-class-12th-physics-india/in-in-wave-optics/x51bd77206da864f3:young-s-double-slit-experiment/v/youngs-double-split-part-1)
 
 ## References
 


### PR DESCRIPTION
Updated three Khan Academy video links that were failing during MyST build link validation:

- Polarization.md (line 227): Updated polarization of light video URL to AP Physics 2 curriculum path
- InterferenceCoherence.md (line 1379): Updated wave interference video URL to AP Physics 1 curriculum path
- InterferenceCoherence.md (line 1396): Updated Young's double slit experiment video URL to Class 12 Physics India curriculum path

Khan Academy reorganized their content structure from the general /science/physics/light-waves/ path to curriculum-specific paths. All videos remain available at their new locations.

Fixes #27