### PR TITLE
Fix issue #25 in optics textbook

### DIFF
--- a/content/Appendices/ComplexNumbers.md
+++ b/content/Appendices/ComplexNumbers.md
@@ -1,3 +1,4 @@
+(appendix:complex-numbers)=
 # Appendix A: Complex Numbers in Optics
 
 ```{epigraph}

--- a/content/Appendices/FourierTransform.md
+++ b/content/Appendices/FourierTransform.md
@@ -1,3 +1,4 @@
+(appendix:fourier-transform)=
 # Appendix C: Fourier Transform in Optics
 
 ```{epigraph}

--- a/content/Appendices/MatrixMultiplication.md
+++ b/content/Appendices/MatrixMultiplication.md
@@ -1,3 +1,4 @@
+(appendix:matrix-multiplication)=
 # Appendix B: Matrix Multiplication in Optics
 
 ```{epigraph}

--- a/content/Appendices/VectorCalculus.md
+++ b/content/Appendices/VectorCalculus.md
@@ -1,3 +1,4 @@
+(appendix:vector-calculus)=
 # Appendix D: Vector Calculus for Electromagnetic Fields
 
 ```{epigraph}

--- a/content/Chap01Basics/Basics.md
+++ b/content/Chap01Basics/Basics.md
@@ -138,7 +138,14 @@ All electromagnetic waves, regardless of their wavelength or frequency, travel a
 The relationship between wavelength $\lambda$ and frequency $\nu$ is given by:
 $$c = \lambda\nu $$
 
-This simple equation reveals an inverse relationship: as wavelength increases, frequency decreases proportionally. The energy of electromagnetic radiation is quantized in units called photons, with each photon carrying energy $E = h\nu$, where $h$ is Planck's constant. This quantization means that electromagnetic waves can only gain or lose energy in discrete amounts proportional to their frequency.
+This simple equation reveals an inverse relationship: as wavelength increases, frequency decreases proportionally. The energy of electromagnetic radiation is quantized in units called photons, with each photon carrying energy:
+
+```{math}
+:label: photon-energy
+E = h\nu
+```
+
+where $h$ is Planck's constant. This quantization means that electromagnetic waves can only gain or lose energy in discrete amounts proportional to their frequency.
 
 
 ```{figure} Images/01_02_electromagnetic_spectrum_f1.png


### PR DESCRIPTION
This commit resolves all 12 warnings from the MyST build by:

1. Adding missing MyST labels to appendix files:
   - ComplexNumbers.md: appendix:complex-numbers
   - MatrixMultiplication.md: appendix:matrix-multiplication
   - FourierTransform.md: appendix:fourier-transform
   - VectorCalculus.md: appendix:vector-calculus

2. Creating the photon-energy equation label:
   - Added labeled equation in Basics.md for E = hν
   - This resolves references from SearchAndNavigation.md and MathematicalNotation.md

All changes validated with validate_references_enhanced.py script, which reports zero validation issues.

Fixes #25