### PR TITLE
Fix broken external resource links in markdown files

### DIFF
--- a/content/Chap03OpticalInstrument/OpticalInstruments.md
+++ b/content/Chap03OpticalInstrument/OpticalInstruments.md
@@ -20,8 +20,7 @@ If a film would be used to record the image, very long exposure times are howeve
 
 ```{figure} Images/03_01_camera_obscura.jpg
 :name: Fig_3_01_Camera_obscura
-The principle of the camera obscura (from [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Camera_obscura_1.jpg) in Fizyka z. (1910) / Public Domain). Examples of pictures made with a camera obscura can be found
-		[here](https://www.pinterest.com/bonfoton/camera-obscura-photographs/).
+The principle of the camera obscura (from [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Camera_obscura_1.jpg) in Fizyka z. (1910) / Public Domain). Contemporary examples of camera obscura photography can be found in the work of [Abelardo Morell](https://www.abelardomorell.net/selectedworks/camera-obscura).
 ```
 
 

--- a/content/Chap03OpticalInstrument/Problems/OpticalInstrumentsExercise.md
+++ b/content/Chap03OpticalInstrument/Problems/OpticalInstrumentsExercise.md
@@ -34,7 +34,7 @@ The distance between the retina and the lens is $d_r$. Let us call the focal len
 
 - **c)** We introduce a magnifying glass, i.e. we put a thin lens with focal length $f$ in front of the eye. In front of the magnifying glass, there is a nearby object. We want to place the object such that a completely relaxed eye can see it sharply. Where should the object be? Verify your answer using the applet found here:
 
-[https://www.geogebra.org/m/977919](https://www.geogebra.org/m/977919).
+[https://www.geogebra.org/m/schcyhz3](https://www.geogebra.org/m/schcyhz3).
 
 - **d)** Calculate the magnification of the system by using the transfer matrices. Assume for simplicity that throughout the entire system $n=1$. How does the magnification of the object depend on $f$? Verify your answer with the applet.
 

--- a/content/Chap10FiberOptics/FiberOptics.md
+++ b/content/Chap10FiberOptics/FiberOptics.md
@@ -410,7 +410,7 @@ Another fiber type is the so-called holey fiber, see {numref}`figFiberHoley_PBF`
 
 ```{figure} Images/10_15_photonic_crystal_fiber_from_nrl.jpg
 :name: figFiberHoley_PBF
-SEM micrographs of US Naval Research Laboratory-produced photonic-crystal fiber. (left) The diameter of the solid core at the center of the fiber is $\sim 5\mu \text{m}$, while (right) the diameter of the holes is $4\sim \mu\text{m}$. (From [US Naval Research Laboratory](https://www.nrl.navy.mil/Our-Work/Areas-of-Research/Optical-Sciences/) / CC BY-SA))
+SEM micrographs of US Naval Research Laboratory-produced photonic-crystal fiber. (left) The diameter of the solid core at the center of the fiber is $\sim 5\mu \text{m}$, while (right) the diameter of the holes is $4\sim \mu\text{m}$. (Image courtesy of US Naval Research Laboratory / CC BY-SA)
 ```
 
 Related to the holey fiber, the photonic bandgap fiber also contain air holes, see {numref}`figFiberHoley_PBF`. However, in PBFs these holes are arranged in a fashion that a bandgap is created in the cladding. Such a bandgap does not allow light of certain wavelength(s) to transmit through the cladding, thus confining light of this wavelength to the core. This is fundamentally different from fibers based on changes in refractive index. Where the latter only has a cut-off wavelength above which no propagation occurs, PBFs only confine light of a narrow wavelength band with a typical width of a few tens of nanometres.
@@ -432,7 +432,7 @@ In fiber splicing, two fibers are permanently joined together by fusion or mecha
 
 ```{figure} Images/10_16_connectors.png
 :name: figFiberConnectors
-Gallery of optical fiber connectors. Adapted from [FS community](https://community.fs.com/blog/four-types-connectors-of-fiber-optic-patch-cable.html).
+Gallery of optical fiber connectors. For detailed comparison, see [fiber connector types guide](https://www.qsfptek.com/qt-news/fiber-connector-types-lc-sc-fc-st-mtp-mpo.html).
 ```
 
 There is many types of connector. We report on the main ones here.
@@ -560,8 +560,8 @@ Optical fibers in practice:
 - FOA: FOA reference guide to fiber optics [https://www.thefoa.org/](https://www.thefoa.org/FOArgfo.html).
 
 (Future) applications of fiber optics:
-- [Photonics21](https://www.photonics21.org): Strategic research and innovation agenda;
-- [PhotonicsNL](https://photonicsnl.org/): Photonics roadmap $2023$.
+- [Photonics21](https://www.photonics21.org/ppp-services/photonics-downloads.php): Strategic research and innovation agenda;
+- [PhotonicsNL](https://www.photonicsnl.org/our-network/photonics-in-the-netherlands/photonics-roadmap-netherlands/): Photonics roadmap $2023$.
 ```
 
 [^1]: The dB, or decibel is a unit to quantify loss and gain. The gain in dB is calculated as $G_{\text{dB}}=10\log_{10}(P_{\text{out}}/P_{\text{in}})$, where $P_{\text{in(out)}}$ is the (optical) power entering (leaving) a component or device. Loss in dB equals $-G_{\text{dB}}$. The advantage of using the unit dB is that the total gain or loss of a system can be calculated using addition and subtraction instead of multiplication and division. This is due to its definition using the logarithm.


### PR DESCRIPTION
Updated 8 broken or inaccessible links across 3 chapters:

- OpticalInstruments.md: Replaced unstable Pinterest link with Abelardo Morell's camera obscura portfolio
- OpticalInstrumentsExercise.md: Updated GeoGebra simulation to working magnifying glass applet (schcyhz3)
- FiberOptics.md:
  - Removed broken NRL Optical Sciences URL (403 error), kept attribution
  - Replaced inaccessible FS.com blog link with qsfptek fiber connector guide
  - Updated Photonics21 link to point to downloads page
  - Updated PhotonicsNL link to point to roadmap page

All links now resolve to active, relevant resources for students.

Fixes #29