### PR TITLE
Fix GitHub Actions build by removing unnecessary Typst installation

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -111,11 +111,6 @@ jobs:
           echo "LATEX_SETUP_TIME=$DURATION" >> $GITHUB_ENV
           echo "STEP_START_TIME=$(date +%s)" >> $GITHUB_ENV
 
-      - name: Install Typst
-        uses: typst-community/setup-typst@v4
-        with:
-          cache-dependency-path: requirements.typ
-      
       - name: Cache build artifacts
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
The Typst export is disabled in myst.yml (lines 51-77) due to compatibility issues, but the workflow was still trying to install Typst with a non-existent requirements.typ file, causing build failures.

This commit removes the unnecessary Typst installation step, which should resolve the GitHub Actions build failure.

Related to Typst being disabled due to:
- LaTeX-specific commands like \boxed not supported in Typst
- Some admonition types not recognized
- Bibliography handling needs improvement
- WebP images need imagemagick for conversion